### PR TITLE
feat: implement responsive card container with grid layout and adaptive stacking for mobile

### DIFF
--- a/frontend/src/components/SymbolCard/SymbolCard.tsx
+++ b/frontend/src/components/SymbolCard/SymbolCard.tsx
@@ -1,5 +1,7 @@
 import './symbolCard.css';
 import { ReactComponent as CompanyIcon } from '@/assets/company.svg';
+import { ReactComponent as IndustryIcon } from '@/assets/industry.svg';
+import { ReactComponent as MarketCapIcon } from '@/assets/market_cap.svg';
 import { useAppSelector } from '@/hooks/redux';
 import ListItem from '@/components/ListItem';
 
@@ -10,7 +12,9 @@ type SymbolCardProps = {
 };
 
 const SymbolCard = ({ id, onClick, price }: SymbolCardProps) => {
-  const { trend, companyName } = useAppSelector((state) => state.stocks.entities[id]);
+  const { trend, companyName, industry, marketCap } = useAppSelector(
+    (state) => state.stocks.entities[id]
+  );
   const handleOnClick = () => {
     onClick(id);
   };
@@ -21,7 +25,9 @@ const SymbolCard = ({ id, onClick, price }: SymbolCardProps) => {
       </div>
       <div>Price:</div>
       <div>{price || '--'} </div>
-      <ListItem Icon={<CompanyIcon />} label={companyName} />
+      <ListItem Icon={<CompanyIcon />} label={companyName} spacing="space-between" />
+      <ListItem Icon={<IndustryIcon />} label={industry} spacing="space-between" />
+      <ListItem Icon={<MarketCapIcon />} label={marketCap.toString()} spacing="space-between" />
     </div>
   );
 };

--- a/frontend/src/components/SymbolCard/symbolCard.css
+++ b/frontend/src/components/SymbolCard/symbolCard.css
@@ -1,8 +1,12 @@
 .symbolCard {
-  border: 2px solid black; /* just for visibility, feel free to remove it */
-  margin: 10px; /* just for visibility, feel free to remove it */
-  padding: 10px; /* just for visibility, feel free to remove it */
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  padding: 16px;
+  background-color: white;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.05);
+  transition: transform 0.2s ease-in-out;
 }
+
 
 .symbolCard__shake {
   animation: shake 0.62s cubic-bezier(0.36, 0.07, 0.19, 0.97) both;

--- a/frontend/src/components/SymbolsGrid/SymbolsGrid.tsx
+++ b/frontend/src/components/SymbolsGrid/SymbolsGrid.tsx
@@ -1,3 +1,4 @@
+import './symbolsGrid.css';
 import { useEffect } from 'react';
 import { useAppDispatch, useAppSelector } from '@/hooks/redux';
 import SymbolCard from '../SymbolCard';
@@ -15,7 +16,7 @@ const SymbolsGrid = ({ onSymbolClick }: SymbolsGridProps) => {
   }, [dispatch]);
 
   return (
-    <div>
+    <div className="symbolsGrid">
       {stockSymbols.map((id, i) => (
         <SymbolCard price={prices[id]} onClick={onSymbolClick} key={i} id={id} />
       ))}

--- a/frontend/src/components/SymbolsGrid/symbolsGrid.css
+++ b/frontend/src/components/SymbolsGrid/symbolsGrid.css
@@ -1,0 +1,12 @@
+.symbolsGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+  gap: 16px; 
+  padding: 16px;
+}
+
+@media (max-width: 600px) {
+  .symbolsGrid {
+    grid-template-columns: 1fr; 
+  }
+}

--- a/frontend/src/components/SymbolsView/SymbolsView.tsx
+++ b/frontend/src/components/SymbolsView/SymbolsView.tsx
@@ -1,3 +1,4 @@
+import './symbolsView.css';
 import SymbolsGrid from '@/components/SymbolsGrid';
 import PriceChart from '@/components/PriceChart';
 import DesktopInfo from './src/DesktopInfo';
@@ -10,18 +11,18 @@ const SymbolsView = () => {
   };
 
   return (
-      <div className="symbolsView">
-        <DesktopInfo/>
+    <div className="symbolsView">
+      <DesktopInfo />
+      <div className="symbolsView__content">
+        <div className="symbolsView__cards">
+          <SymbolsGrid onSymbolClick={handleSymbolClick} />
+        </div>
         <div className="symbolsView__chart">
           <h3>PRICE HISTORY</h3>
-        </div>
-        <div className="symbolsView__content">
-          <PriceChart symbolId={activeSymbol}/>
-          <div className="symbolsView__cards">
-            <SymbolsGrid onSymbolClick={handleSymbolClick}/>
-          </div>
+          <PriceChart symbolId={activeSymbol} />
         </div>
       </div>
+    </div>
   );
 };
 

--- a/frontend/src/components/SymbolsView/symbolsView.css
+++ b/frontend/src/components/SymbolsView/symbolsView.css
@@ -1,0 +1,54 @@
+.symbolsView {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  padding: 16px;
+  box-sizing: border-box;
+}
+
+.symbolsView__content {
+  display: grid;
+  grid-template-columns: 1fr 400px;
+  gap: 16px;
+  flex-grow: 1;
+  overflow: hidden;
+}
+
+.symbolsView__cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 16px;
+  overflow-y: auto;
+  padding-right: 8px;
+}
+
+.symbolsView__chart {
+  background-color: var(--colorWhite);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  border-radius: 8px;
+  padding: 24px;
+  height: 100%;
+}
+
+/* Scrollbar Styling */
+.symbolsView__cards::-webkit-scrollbar {
+  width: 8px;
+}
+
+.symbolsView__cards::-webkit-scrollbar-thumb {
+  background-color: #bbb;
+  border-radius: 8px;
+}
+
+/* Responsive Layout */
+@media (max-width: 1024px) {
+  .symbolsView__content {
+    grid-template-columns: 1fr;
+    grid-template-rows: auto 1fr;
+  }
+
+  .symbolsView__chart {
+    order: -1; /* Move chart to the top */
+    width: 100%;
+  }
+}


### PR DESCRIPTION
**Build Responsive Card Container**:

- Implement a grid/flexbox layout for the stock cards.

- Ensure the card container is scrollable within its own section.

- Adjust layout based on screen size (desktop, tablet, mobile).

- On desktop, the price chart should take 400px on the right; on mobile/tablet, it stacks on top.