### PR TITLE
feat: Hide scrollbar in symbolsView__cards while maintaining scroll functionality

### DIFF
--- a/frontend/src/components/SymbolsView/symbolsView.css
+++ b/frontend/src/components/SymbolsView/symbolsView.css
@@ -21,6 +21,8 @@
   overflow-y: auto;
   padding-right: 8px;
   background-color: #f5f5f5;
+  scrollbar-width: none; 
+  -ms-overflow-style: none; 
 }
 
 .symbolsView__chart {
@@ -28,14 +30,8 @@
   height: 100%;
 }
 
-/* Scrollbar Styling */
 .symbolsView__cards::-webkit-scrollbar {
-  width: 8px;
-}
-
-.symbolsView__cards::-webkit-scrollbar-thumb {
-  background-color: #bbb;
-  border-radius: 8px;
+  display: none;
 }
 
 /* Responsive Layout */


### PR DESCRIPTION
Hide scrollbar in symbolsView__cards while maintaining scroll functionality